### PR TITLE
zm - Fix plus()/Add test

### DIFF
--- a/javascript/src/main/rationals/Rational.js
+++ b/javascript/src/main/rationals/Rational.js
@@ -29,13 +29,8 @@ export default class Rational {
     if (other.numerator === 0)
       return new Rational(this.numerator, this.denominator);
 
-    const numGCD = gcd(this.numerator, other.numerator);
-    const denomGCD = gcd(this.denominator, other.denominator);
-
-    const numerator =
-      (this.numerator / numGCD) * (other.denominator / denomGCD) +
-      (other.numerator / numGCD) * (this.denominator / denomGCD);
     const denominator = lcm(this.denominator, other.denominator);
+    const numerator = (denominator*this.numerator)/this.denominator + (denominator*other.numerator)/other.denominator;
 
     return new Rational(numerator, denominator);
   }

--- a/javascript/src/test/rationals/Rational.test.js
+++ b/javascript/src/test/rationals/Rational.test.js
@@ -3,6 +3,7 @@ import Rational from "main/rationals/Rational";
 describe("Rational class tests", () => {
   const oneThird = new Rational(1, 3);
   const twoThirds = new Rational(2, 3);
+  const twoSevenths = new Rational(2, 7);
   const negativeOne = new Rational(-1, 1);
   const one = new Rational(1, 1);
   const zero = new Rational(0, 1);
@@ -64,6 +65,13 @@ describe("Rational class tests", () => {
     test("(1 pts) 1/3 + 2/3 = 1/1", () => {
       const expected = new Rational(1, 1);
       const actual = oneThird.plus(twoThirds);
+
+      expect(actual).toMatchObject(expected);
+    });
+
+    test("(0 pts) 2/7 + 2/3 = 20/21", () => {
+      const expected = new Rational(20, 21);
+      const actual = twoSevenths.plus(twoThirds);
 
       expect(actual).toMatchObject(expected);
     });


### PR DESCRIPTION
The current implementation of the plus method is incorrect and only causes the tests to pass because the test coverage for this method is inadequate to catch failing cases. I have modified the function to perform the correct calculation and added a test case that the previous implementation would have calculated incorrectly (2/7 + 2/3).